### PR TITLE
docs: add English README version

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,66 @@ myenv/
 # VS Code settings
 .vscode/
 ```
+
+---
+
+# Speech + Visual Recognition System
+
+### Problem Statement
+
+Single speech or visual recognition each have its limitations:
+- Speech recognition requires sound source localization and often relies on multi-microphone arrays to estimate the sound source and time difference.
+- Visual recognition is limited by resolution and algorithm accuracy.
+
+## Solution: Real-time Subtitle Generation System
+
+Combining audio and visual information improves recognition accuracy and real-time performance.
+![ex](./image/ex.png)
+
+📷 ➜ [Lip detection + tracking] ➜ [Select speaker] ➜ Record audio ➜ Speech recognition ➜ Display subtitles
+![ex2](./image/ex2.png)
+
+## Files and Models
+
+| File | Task | Model Used |
+|----------|------|----------|
+| `mouth_tracker.py` | Real-time detection of lip region and speaking status | OpenCV, MediaPipe |
+| `audio_recorder.py` | Synchronized recording | Argparse, sounddevice |
+| `asr_engine.py` | Convert audio to subtitles | Whisper |
+| `subtitle_overlay.py` | Display subtitles | OpenCV |
+
+## Run Locally
+
+```bash
+# Virtual environment
+python3 -m venv myenv
+source myenv/bin/activate
+
+# Install dependencies
+pip install -r requirements.txt
+
+# Run main program
+python main.py
+```
+
+## .gitignore Example
+
+It is recommended to create a `.gitignore` file in the project root to avoid committing unnecessary files:
+
+```gitignore
+# Python
+__pycache__/
+*.pyc
+
+# Virtual environment
+myenv/
+
+# Audio files
+*.wav
+
+# macOS system files
+.DS_Store
+
+# VS Code settings
+.vscode/
+```


### PR DESCRIPTION
## Summary
- Add an English translation of the README detailing the speech + visual recognition system, file roles, setup steps, and a .gitignore example.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ed6f0af38832992db78d57167c414